### PR TITLE
Add support for sysfs on systemd OS

### DIFF
--- a/lib/facter/systemd.rb
+++ b/lib/facter/systemd.rb
@@ -1,0 +1,18 @@
+# Fact: systemd
+#
+# Purpose:
+#   Determine whether systemd is the init system on the node
+#
+# Resolution:
+#   Check if the service_provider fact is systemd
+#
+# Caveats:
+#   If you override the service provider then it will return false, even if the
+#   underlying system still is systemd.
+#
+Facter.add(:systemd) do
+  confine :kernel => :linux
+  setcode do
+    Facter.value(:service_provider) == 'systemd'
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,15 +17,24 @@ define sysfs (
   # Parent purged directory
   include ::sysfs::base
 
-  # The permanent change
-  file { "/etc/sysfs.d/${title}.conf":
-    ensure  => $ensure,
-    owner   => root,
-    group   => root,
-    mode    => '0644',
-    content => template('sysfs/sysfs.erb'),
-    notify  => Service['sysfsutils'],
+  if $facts['systemd'] {
+
+    concat::fragment { "sysfs_systemd_tmpfiles_${title}":
+      target  => 'sysfs_systemd_tmpfiles',
+      content => "# ${comment}\nw /sys/${attribute} - - - - ${value}\n",
+      order   => '200',
+    }
+
+  } else {
+
+    file { "/etc/sysfs.d/${title}.conf":
+      ensure  => $ensure,
+      owner   => root,
+      group   => root,
+      mode    => '0644',
+      content => template('sysfs/sysfs.erb'),
+      notify  => Service['sysfsutils'],
+    }
   }
-# "# ${comment}\n${title} = ${value}\n",
 
 }

--- a/manifests/sysvinit.pp
+++ b/manifests/sysvinit.pp
@@ -1,0 +1,41 @@
+#
+# = Class: sysfs::sysvinit
+#
+class sysfs::sysvinit (
+  $initd_source = 'puppet:///modules/sysfs/init.RedHat',
+){
+
+  File {
+    ensure  => file,
+    owner   => root,
+    group   => root,
+    mode    => '0644',
+    require => Package['sysfsutils'],
+  }
+
+  package { 'sysfsutils':
+    ensure => present,
+  }
+
+  file { '/etc/sysfs.conf':
+    source  => 'puppet:///modules/sysfs/sysfs.conf',
+  }
+
+  file { '/etc/sysfs.d':
+    ensure  => directory,
+    recurse => true,
+    purge   => true,
+  }
+
+  file { '/etc/init.d/sysfsutils':
+    mode   => '0755',
+    source => $initd_source,
+    before => Service['sysfsutils'],
+  }
+
+  service { 'sysfsutils':
+    ensure  => running,
+    enable  => true,
+  }
+
+}


### PR DESCRIPTION
This module uses sysvinit script for EL6 and boot-persistent sysfs tunables.

On CentOS 7 and other systemd based distributions, we can use a tmpfiles [trick](https://stackoverflow.com/questions/27511139/how-to-make-sysfs-changes-persistent-in-centos-7-systemd).